### PR TITLE
Listen on all IPv4 and IPv6 addresses, not just IPv4

### DIFF
--- a/root/etc/s6-overlay/s6-rc.d/service-sabnzbd/run
+++ b/root/etc/s6-overlay/s6-rc.d/service-sabnzbd/run
@@ -4,4 +4,4 @@
 umask "${UMASK}"
 
 # shellcheck disable=SC2086
-exec s6-setuidgid hotio python3 "${APP_DIR}/SABnzbd.py" --browser 0 --server "0.0.0.0:${WEBUI_PORTS%%/*}" --config-file "${CONFIG_DIR}/sabnzbd.ini" ${ARGS}
+exec s6-setuidgid hotio python3 "${APP_DIR}/SABnzbd.py" --browser 0 --server "[::]:${WEBUI_PORTS%%/*}" --config-file "${CONFIG_DIR}/sabnzbd.ini" ${ARGS}


### PR DESCRIPTION
`0.0.0.0` will only listen on all IPv4 addresses, whereas `::` will listen to all IPv6 addresses and all IPv4 addresses.
